### PR TITLE
Add scripts for Google Ads click performance Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-starter file
+# Google Ads Click Parameters
+
+This repository contains a sample AWS Lambda function for collecting click
+performance data from the Google Ads API and storing it in S3 and DynamoDB.
+It also provides a small utility script for exporting an initial historical
+load from a warehouse table.
+
+## Lambda Function
+
+`lambda_function.py` downloads recent clicks from Google Ads. Each invocation
+queries all clicks since the last successful run (tracked in an S3 pointer
+file) and writes them to both DynamoDB and S3.
+
+Set the following environment variables in your Lambda configuration:
+
+- `GOOGLE_ADS_SECRET_NAME` – name of the Secrets Manager secret with OAuth
+  and Ads API credentials.
+- `GOOGLE_ADS_CUSTOMER_ID` – Google Ads customer account ID.
+- `S3_BUCKET` – S3 bucket for JSON dumps.
+- `DYNAMO_TABLE_NAME` – DynamoDB table for lookup by gclid.
+- Optional variables such as `S3_KEY_PREFIX`, `S3_POINTER_KEY` and
+  `INCREMENT_MINUTES` control S3 locations and the query lookback window.
+
+## Initial Load
+
+`initial_load.py` provides a minimal example of exporting historical data from a
+warehouse (using the Snowflake Python connector) and loading it into the same
+S3 bucket and DynamoDB table. Update the Snowflake connection environment
+variables before running it locally or from a one‑off container.
+
+## Running a Syntax Check
+
+To verify the code parses correctly, run:
+
+```bash
+python -m py_compile lambda_function.py initial_load.py
+```

--- a/initial_load.py
+++ b/initial_load.py
@@ -1,0 +1,58 @@
+import os
+import json
+import boto3
+import snowflake.connector
+
+# Environment variables for Snowflake
+SF_ACCOUNT = os.environ['SNOWFLAKE_ACCOUNT']
+SF_USER = os.environ['SNOWFLAKE_USER']
+SF_PASSWORD = os.environ['SNOWFLAKE_PASSWORD']
+SF_WAREHOUSE = os.environ['SNOWFLAKE_WAREHOUSE']
+SF_DATABASE = os.environ['SNOWFLAKE_DATABASE']
+SF_SCHEMA = os.environ['SNOWFLAKE_SCHEMA']
+
+S3_BUCKET = os.environ['S3_BUCKET']
+S3_PREFIX = os.environ.get('S3_KEY_PREFIX', 'click_performance/')
+DDB_TABLE = os.environ['DYNAMO_TABLE_NAME']
+
+TABLE_NAME = 'SEGMENT_EVENTS.GOOGLE_ADS_CLICK_PARAMETERS.CLICK_PERFORMANCE_REPORTS'
+
+s3 = boto3.client('s3')
+ddb = boto3.resource('dynamodb').Table(DDB_TABLE)
+
+
+def fetch_all_rows():
+    ctx = snowflake.connector.connect(
+        user=SF_USER,
+        password=SF_PASSWORD,
+        account=SF_ACCOUNT,
+        warehouse=SF_WAREHOUSE,
+        database=SF_DATABASE,
+        schema=SF_SCHEMA,
+    )
+    cs = ctx.cursor()
+    try:
+        query = f"SELECT * FROM {TABLE_NAME}"
+        cs.execute(query)
+        for row in cs.fetchall():
+            yield dict(zip([c[0] for c in cs.description], row))
+    finally:
+        cs.close()
+        ctx.close()
+
+
+def write_to_dynamodb(rows):
+    for r in rows:
+        ddb.put_item(Item=r)
+
+
+def dump_to_s3(rows, key):
+    s3.put_object(Bucket=S3_BUCKET, Key=key, Body=json.dumps(rows))
+
+
+if __name__ == '__main__':
+    rows = list(fetch_all_rows())
+    key = f"{S3_PREFIX}initial_load.json"
+    dump_to_s3(rows, key)
+    write_to_dynamodb(rows)
+    print(f"Wrote {len(rows)} records to S3 and DynamoDB")

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -1,0 +1,116 @@
+import os
+import json
+from datetime import datetime, timedelta
+import boto3
+from google.ads.googleads.client import GoogleAdsClient
+from google.ads.googleads.errors import GoogleAdsException
+import yaml
+
+# Environment variables
+SECRET_NAME = os.environ['GOOGLE_ADS_SECRET_NAME']
+REGION = os.environ.get('AWS_REGION', 'us-east-1')
+CUSTOMER_ID = os.environ['GOOGLE_ADS_CUSTOMER_ID']
+S3_BUCKET = os.environ['S3_BUCKET']
+S3_PREFIX = os.environ.get('S3_KEY_PREFIX', 'click_performance/')
+DDB_TABLE = os.environ['DYNAMO_TABLE_NAME']
+POINTER_KEY = os.environ.get('S3_POINTER_KEY', 'click_performance/last_run_pointer.json')
+LOOKBACK_MIN = int(os.environ.get('INCREMENT_MINUTES', '5'))
+
+s3 = boto3.client('s3')
+ddb = boto3.resource('dynamodb').Table(DDB_TABLE)
+
+
+def get_secret():
+    sm = boto3.client('secretsmanager', region_name=REGION)
+    return json.loads(sm.get_secret_value(SecretId=SECRET_NAME)['SecretString'])
+
+
+def build_client(creds):
+    cfg = {
+        'developer_token': creds['developer_token'],
+        'client_id': creds['client_id'],
+        'client_secret': creds['client_secret'],
+        'refresh_token': creds['refresh_token'],
+        'login_customer_id': creds['login_customer_id'],
+    }
+    path = '/tmp/google-ads.yaml'
+    with open(path, 'w') as fh:
+        fh.write(yaml.dump(cfg))
+    return GoogleAdsClient.load_from_storage(path)
+
+
+def get_last_run():
+    try:
+        obj = s3.get_object(Bucket=S3_BUCKET, Key=POINTER_KEY)
+        return json.loads(obj['Body'].read().decode())['last_run_ts']
+    except s3.exceptions.NoSuchKey:
+        return (datetime.utcnow() - timedelta(minutes=LOOKBACK_MIN)).isoformat()
+
+
+def set_last_run(ts):
+    s3.put_object(Bucket=S3_BUCKET, Key=POINTER_KEY, Body=json.dumps({'last_run_ts': ts}))
+
+
+def query_clicks(client, customer_id, start_ts, end_ts):
+    service = client.get_service('GoogleAdsService')
+    query = f"""
+        SELECT click_view.gclid, campaign.id, ad_group_ad.ad.id,
+               click_view.ad_network_type, segments.date_time
+        FROM click_view
+        WHERE segments.date_time BETWEEN '{start_ts}' AND '{end_ts}'
+    """
+    results = []
+    try:
+        for batch in service.search_stream(customer_id=customer_id, query=query):
+            for row in batch.results:
+                results.append({
+                    'click_performance': {
+                        'gclid': row.click_view.gclid,
+                        'campaign_id': row.campaign.id,
+                        'creative_id': row.ad_group_ad.ad.id,
+                        'ad_network_type': row.click_view.ad_network_type.name,
+                        'timestamp': row.segments.date_time.value,
+                    }
+                })
+    except GoogleAdsException as exc:
+        print('Google Ads API error:', exc)
+        raise
+    return results
+
+
+def write_to_dynamodb(items):
+    for item in items:
+        ddb.put_item(Item={
+            'gclid': item['click_performance']['gclid'],
+            'campaign_id': item['click_performance']['campaign_id'],
+            'creative_id': item['click_performance']['creative_id'],
+            'ad_network_type': item['click_performance']['ad_network_type'],
+            'timestamp': item['click_performance']['timestamp'],
+        })
+
+
+def lambda_handler(event, context):
+    creds = get_secret()
+    client = build_client(creds)
+
+    last_run_ts = get_last_run()
+    now_ts = datetime.utcnow().isoformat()
+
+    data = query_clicks(client, CUSTOMER_ID, last_run_ts, now_ts)
+
+    if not data:
+        set_last_run(now_ts)
+        return {'statusCode': 204, 'body': 'no data'}
+
+    ts = datetime.utcnow().strftime('%Y-%m-%dT%H-%M-%SZ')
+    key = f"{S3_PREFIX}clicks_{ts}.json"
+    s3.put_object(Bucket=S3_BUCKET, Key=key, Body=json.dumps(data))
+
+    write_to_dynamodb(data)
+
+    set_last_run(now_ts)
+
+    return {
+        'statusCode': 200,
+        'body': f"{len(data)} records written to S3 and DynamoDB",
+    }


### PR DESCRIPTION
## Summary
- add AWS Lambda function to fetch recent Google Ads clicks
- provide example script for initial historical export from Snowflake
- document usage and syntax check instructions

## Testing
- `python -m py_compile lambda_function.py initial_load.py`

------
https://chatgpt.com/codex/tasks/task_b_684078765720832b9023b6075995a1b6