### PR TITLE
Fix RDS connection cleanup and optimize DynamoDB writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Set the following environment variables in your Lambda configuration:
 - Optional variables such as `S3_KEY_PREFIX`, `S3_POINTER_KEY` and
   `INCREMENT_MINUTES` control S3 locations and the query lookback window.
 
+The Lambda automatically refreshes the OAuth access token using the stored
+refresh token on each invocation. If Google returns a new refresh token it is
+written back to Secrets Manager so subsequent runs use the updated credential.
+
 ## Initial Load
 
 `initial_load.py` provides a minimal example of exporting historical data from a

--- a/initial_load.py
+++ b/initial_load.py
@@ -42,8 +42,9 @@ def fetch_all_rows():
 
 
 def write_to_dynamodb(rows):
-    for r in rows:
-        ddb.put_item(Item=r)
+    with ddb.batch_writer() as batch:
+        for r in rows:
+            batch.put_item(Item=r)
 
 
 def dump_to_s3(rows, key):

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -4,10 +4,12 @@ import logging
 from datetime import datetime, timedelta
 import psycopg2
 import boto3
-import yaml
 
 from google.ads.googleads.client import GoogleAdsClient
 from google.ads.googleads.errors import GoogleAdsException
+from google.auth.exceptions import RefreshError
+from google.oauth2.credentials import Credentials
+from google.auth.transport.requests import Request
 
 # --- Logging ---
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -35,20 +37,32 @@ ddb = boto3.resource('dynamodb').Table(DDB_TABLE)
 def get_secret():
     return json.loads(sm.get_secret_value(SecretId=SECRET_NAME)['SecretString'])
 
+def refresh_google_oauth(creds):
+    cred_obj = Credentials(
+        None,
+        refresh_token=creds['refresh_token'],
+        client_id=creds['client_id'],
+        client_secret=creds['client_secret'],
+        token_uri='https://oauth2.googleapis.com/token'
+    )
+    cred_obj.refresh(Request())
+    if cred_obj.refresh_token and cred_obj.refresh_token != creds['refresh_token']:
+        creds['refresh_token'] = cred_obj.refresh_token
+        sm.put_secret_value(SecretId=SECRET_NAME,
+                            SecretString=json.dumps(creds))
+        logger.info('Stored new refresh token in Secrets Manager')
+    return cred_obj
+
 def build_client(creds):
-    path = '/tmp/google-ads.yaml'
-    yaml_config = {
-        'developer_token': creds['developer_token'],
-        'client_id': creds['client_id'],
-        'client_secret': creds['client_secret'],
-        'refresh_token': creds['refresh_token'],
-        'login_customer_id': creds['login_customer_id'],
-    }
-    with open(path, 'w') as fh:
-        yaml.dump(yaml_config, fh)
-    return GoogleAdsClient.load_from_storage(path)
+    cred_obj = refresh_google_oauth(creds)
+    return GoogleAdsClient(
+        credentials=cred_obj,
+        developer_token=creds['developer_token'],
+        login_customer_id=creds['login_customer_id']
+    )
 
 def get_last_run():
+    conn = None
     try:
         conn = psycopg2.connect(
             host=RDS_HOST, database=RDS_DB,
@@ -68,6 +82,7 @@ def get_last_run():
             conn.close()
 
 def set_last_run(ts):
+    conn = None
     try:
         conn = psycopg2.connect(
             host=RDS_HOST, database=RDS_DB,
@@ -113,8 +128,9 @@ def query_clicks(client, customer_id, start_ts, end_ts):
     return results
 
 def write_to_dynamodb(items):
-    for item in items:
-        ddb.put_item(Item=item)
+    with ddb.batch_writer() as batch:
+        for item in items:
+            batch.put_item(Item=item)
 
 # --- Lambda Entrypoint ---
 def lambda_handler(event, context):
@@ -127,9 +143,23 @@ def lambda_handler(event, context):
     logger.info(f"Running for time window: {start_ts} -> {end_ts}")
     all_data = []
 
-    for cid in list_customer_ids(client):
+    try:
+        customer_ids = list_customer_ids(client)
+    except RefreshError:
+        logger.info("OAuth token expired, reloading credentials")
+        creds = get_secret()
+        client = build_client(creds)
+        customer_ids = list_customer_ids(client)
+
+    for cid in customer_ids:
         logger.info(f"Processing customer {cid}")
-        rows = query_clicks(client, cid, start_ts, end_ts)
+        try:
+            rows = query_clicks(client, cid, start_ts, end_ts)
+        except RefreshError:
+            logger.info("OAuth token expired during query, reloading credentials")
+            creds = get_secret()
+            client = build_client(creds)
+            rows = query_clicks(client, cid, start_ts, end_ts)
         all_data.extend(rows)
 
     if not all_data:


### PR DESCRIPTION
## Summary
- prevent `UnboundLocalError` when RDS connection fails
- batch writes to DynamoDB for better performance
- refresh OAuth tokens every run and persist new refresh token back to Secrets Manager

## Testing
- `python -m py_compile lambda_function.py initial_load.py`


------
https://chatgpt.com/codex/tasks/task_b_6841cf438334832b922f135efb3872e9